### PR TITLE
Fix Image import to work with Pillow 3.0+

### DIFF
--- a/mapping/enable/canvas.py
+++ b/mapping/enable/canvas.py
@@ -30,11 +30,10 @@ class MappingCanvas(Canvas):
 
     def __blank_tile_default(self):
         import pkg_resources
-        from PIL import Image as pil
-        import ImageDraw
-        import ImageFont
+        from PIL import Image as PilImage
+        from PIL import ImageDraw, ImageFont
 
-        im = pil.new('RGB', (256, 256), (234, 224, 216))
+        im = PilImage.new('RGB', (256, 256), (234, 224, 216))
 
         text = 'Image not available'
         try:

--- a/mapping/enable/canvas.py
+++ b/mapping/enable/canvas.py
@@ -22,7 +22,7 @@ class MappingCanvas(Canvas):
     tile_alpha = Range(0.0, 1.0, 1.0)
 
     bgcolor = ColorTrait("lightsteelblue")
-    
+
     # FIXME This is a hack - remove when viewport is fixed
     _zoom_level = Int(0)
 
@@ -30,7 +30,7 @@ class MappingCanvas(Canvas):
 
     def __blank_tile_default(self):
         import pkg_resources
-        import Image as pil
+        from PIL import Image as pil
         import ImageDraw
         import ImageFont
 
@@ -64,7 +64,7 @@ class MappingCanvas(Canvas):
 
     def _draw_background(self, gc, view_bounds=None, mode="default"):
         if self.bgcolor not in ("clear", "transparent", "none"):
-            with gc: 
+            with gc:
                 gc.set_antialias(False)
                 gc.set_fill_color(self.bgcolor_)
                 gc.draw_rect(view_bounds, FILL)
@@ -106,7 +106,7 @@ class MappingCanvas(Canvas):
 
     def transformToWSG84(self, x, y):
         return self._screen_to_WGS84(x, y, self._zoom_level)
-    
+
     def _WGS84_to_screen(self, lat_deg, lon_deg, zoom):
         """
          lat = Latitude in degrees
@@ -116,7 +116,7 @@ class MappingCanvas(Canvas):
         lat_rad = math.radians(lat_deg)
         mapsize = self.tile_cache.get_tile_size() << zoom
         x = (lon_deg + 180.0) / 360.0 * mapsize
-        y = (1- (1.0 - math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad))) / math.pi) 
+        y = (1- (1.0 - math.log(math.tan(lat_rad) + (1 / math.cos(lat_rad))) / math.pi)
                     / 2.0) * mapsize
         return (x, y)
 

--- a/mapping/enable/tests/test_canvas.py
+++ b/mapping/enable/tests/test_canvas.py
@@ -8,10 +8,10 @@ from mapping.enable.api import MBTileManager
 
 class TestMappingCanvas(TestCase):
     def setUp(self):
-        tile_layer = MBTileManager(filename = 'map.mbtiles',
-                                   min_level=2,  max_level=4)
+        tile_layer = MBTileManager(filename='map.mbtiles',
+                                   min_level=2, max_level=4)
 
-        self.canvas = MappingCanvas(tile_cache = tile_layer)
+        self.canvas = MappingCanvas(tile_cache=tile_layer)
 
     def test__blank_tile(self):
         self.assertIsInstance(self.canvas._blank_tile, Image)

--- a/mapping/enable/tests/test_canvas.py
+++ b/mapping/enable/tests/test_canvas.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+
+from kiva.image import Image
+
+from mapping.enable.canvas import MappingCanvas
+from mapping.enable.api import MBTileManager
+
+
+class TestMappingCanvas(TestCase):
+    def setUp(self):
+        tile_layer = MBTileManager(filename = 'map.mbtiles',
+                                   min_level=2,  max_level=4)
+
+        self.canvas = MappingCanvas(tile_cache = tile_layer)
+
+    def test__blank_tile(self):
+        self.assertIsInstance(self.canvas._blank_tile, Image)


### PR DESCRIPTION
The new Pillow 3.0.x has `import Image` deprecated and raising an error. This PR fixes it by replacing with `from PIL import Image`.

Should merge https://github.com/enthought/enable-mapping/pull/2 first.
