### PR TITLE
Fix some old-style except clauses; the variable wasn't needed anyway.

### DIFF
--- a/mapping/enable/async_loader.py
+++ b/mapping/enable/async_loader.py
@@ -42,11 +42,11 @@ class RequestingThread(Thread):
                 for req in reqs:
                     try:
                         req.connect()
-                    except socket.gaierror as e:
+                    except socket.gaierror:
                         # Don't panic, the server is not available
                         pass
 
-            except Queue.Empty, e:
+            except Queue.Empty:
                 pass
             asyncore.loop()
 

--- a/mapping/enable/asynchttp.py
+++ b/mapping/enable/asynchttp.py
@@ -427,7 +427,7 @@ class AsyncHTTPConnection(asynchat.async_chat):
 
         try:
             data = self.recv (self.ac_in_buffer_size)
-        except socket.error, why:
+        except socket.error:
             self.handle_error()
             return
 


### PR DESCRIPTION
Drive-by cleanup: in #8, I noticed that there are old-style except clauses being used (i.e., `except Exception, e:` instead of `except Exception as e:`). This PR fixes those occurrences that aren't already fixed in #8. In all cases I found, the variable wasn't used at all, so `except <ExceptionType>:` is all that's needed.