### PR TITLE
FIX: Use "zoom, row, col" ordering throughout.

### DIFF
--- a/examples/enaml_based/choropleth.py
+++ b/examples/enaml_based/choropleth.py
@@ -34,7 +34,7 @@ def _create_plot_component(max_pop, index_ds, value_ds, color_ds, paths):
 
     tile_cache = HTTPTileManager(min_level=2, max_level=4,
                                  server='tile.cloudmade.com',
-                                 url='/1a1b06b230af4efdbb989ea99e9841af/20760/256/%(zoom)d/%(row)d/%(col)d.png')  # noqa
+                                 url='/1a1b06b230af4efdbb989ea99e9841af/20760/256/%(zoom)d/%(col)d/%(row)d.png')  # noqa
 
     color_range = DataRange1D(color_ds, low_setting=0)
 

--- a/examples/enaml_based/enthought_offices.py
+++ b/examples/enaml_based/enthought_offices.py
@@ -55,8 +55,8 @@ class MultiMap(HasTraits):
 
 def main():
     manager = HTTPTileManager(min_level=0, max_level=15,
-                              server='d.tiles.mapbox.com',
-                              url='/v3/mapbox.mapbox-streets/%(zoom)d/%(row)d/%(col)d.png')  # noqa
+                              server='tile.openstreetmap.org',
+                              url='/%(zoom)d/%(col)d/%(row)d.png')
     canvas = MappingCanvas(tile_cache=manager)
 
     nyc = Office(city="New York City", location=(40.7546423, -73.9748948))

--- a/examples/enaml_based/web.py
+++ b/examples/enaml_based/web.py
@@ -6,26 +6,12 @@ from mapping.enable.api import MappingCanvas, MappingViewport, HTTPTileManager
 from mapping.enable.primitives.api import GeoCircle
 
 SERVERS = {
-    'MapQuest': ('otile1.mqcdn.com',
-                 '/tiles/1.0.0/osm/%(zoom)d/%(row)d/%(col)d.jpg'),
-    'MapQuest Aerial': ('oatile1.mqcdn.com',
-                        '/tiles/1.0.0/sat/%(zoom)d/%(row)d/%(col)d.jpg'),
     'OpenStreetMap': ('tile.openstreetmap.org',
-                      '/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox': ('d.tiles.mapbox.com',
-               '/v3/mapbox.mapbox-streets/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox Lacquer': ('d.tiles.mapbox.com',
-                       '/v3/mapbox.mapbox-lacquer/%(zoom)d/%(row)d/%(col)d.png'),  # noqa
-    'MapBox Light': ('d.tiles.mapbox.com',
-                     '/v3/mapbox.mapbox-light/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox Simple': ('d.tiles.mapbox.com',
-                      '/v3/mapbox.mapbox-simple/%(zoom)d/%(row)d/%(col)d.png'),
+                      '/%(zoom)d/%(col)d/%(row)d.png'),
     'Stamen Watercolor': ('a.tile.stamen.com',
-                          '/watercolor/%(zoom)d/%(row)d/%(col)d.jpg'),
-    'Stamen Toner': ('tile.stamen.com',
-                     '/toner/%(zoom)d/%(row)d/%(col)d.jpg'),
+                          '/watercolor/%(zoom)d/%(col)d/%(row)d.jpg'),
     'Stamen Terrain': ('tile.stamen.com',
-                       '/terrain-background/%(zoom)d/%(row)d/%(col)d.png'),
+                       '/terrain-background/%(zoom)d/%(col)d/%(row)d.png'),
 }
 
 
@@ -64,7 +50,7 @@ def main():
     viewport.set(zoom_level=12, geoposition=nyc)
 
     model = SingleMap(canvas=canvas, viewport=viewport)
-    model.server = 'MapBox Simple'
+    model.server = 'OpenStreetMap'
 
     import enaml
     with enaml.imports():

--- a/examples/traitsui_based/web.py
+++ b/examples/traitsui_based/web.py
@@ -13,26 +13,12 @@ from mapping.enable.api import MappingCanvas, MappingViewport, HTTPTileManager
 from mapping.enable.primitives.api import GeoCircle
 
 SERVERS = {
-    'MapQuest': ('otile1.mqcdn.com',
-                 '/tiles/1.0.0/osm/%(zoom)d/%(row)d/%(col)d.jpg'),
-    'MapQuest Aerial': ('oatile1.mqcdn.com',
-                        '/tiles/1.0.0/sat/%(zoom)d/%(row)d/%(col)d.jpg'),
     'OpenStreetMap': ('tile.openstreetmap.org',
-                      '/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox': ('d.tiles.mapbox.com',
-               '/v3/mapbox.mapbox-streets/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox Lacquer': ('d.tiles.mapbox.com',
-                       '/v3/mapbox.mapbox-lacquer/%(zoom)d/%(row)d/%(col)d.png'),  # noqa
-    'MapBox Light': ('d.tiles.mapbox.com',
-                     '/v3/mapbox.mapbox-light/%(zoom)d/%(row)d/%(col)d.png'),
-    'MapBox Simple': ('d.tiles.mapbox.com',
-                      '/v3/mapbox.mapbox-simple/%(zoom)d/%(row)d/%(col)d.png'),
+                      '/%(zoom)d/%(col)d/%(row)d.png'),
     'Stamen Watercolor': ('a.tile.stamen.com',
-                          '/watercolor/%(zoom)d/%(row)d/%(col)d.jpg'),
-    'Stamen Toner': ('tile.stamen.com',
-                     '/toner/%(zoom)d/%(row)d/%(col)d.jpg'),
+                          '/watercolor/%(zoom)d/%(col)d/%(row)d.jpg'),
     'Stamen Terrain': ('tile.stamen.com',
-                       '/terrain-background/%(zoom)d/%(row)d/%(col)d.png'),
+                       '/terrain-background/%(zoom)d/%(col)d/%(row)d.png'),
 }
 
 

--- a/mapping/enable/http_tile_manager.py
+++ b/mapping/enable/http_tile_manager.py
@@ -29,7 +29,7 @@ class HTTPTileManager(TileManager):
         size = self.get_tile_size()
         col = (x / size % n)
         row = (n - 1 - y / size % n)
-        return (zoom, col, row)
+        return (zoom, row, col)
 
     @lru_cache()
     def get_tile(self, zoom, row, col):

--- a/mapping/enable/mbtile_manager.py
+++ b/mapping/enable/mbtile_manager.py
@@ -28,9 +28,9 @@ class MBTileManager(TileManager):
         size = self.get_tile_size()
         col = (x / size % n)
         row = (y / size % n)
-        return (zoom, col, row)
+        return zoom, row, col
 
-    # Public interface #################################################
+    # Public interface ###################################################
 
     filename = Str()
 


### PR DESCRIPTION
This is based on #16 since it's need to test the HTTP tile manager.

Basically, the ordering of `zoom, row, col` was not being respected everywhere, and it led to weird situations and opportunities for bugs. I think it's fairly well sorted now.

I also removed a bunch of tile sources from the example programs since those API endpoints appear to have gone offline.