### PR TITLE
BUG: remove `use_draw_order`

### DIFF
--- a/mapping/chaco/map.py
+++ b/mapping/chaco/map.py
@@ -59,7 +59,7 @@ class Map(AbstractOverlay):
         return
 
     def do_layout(self, *args, **kw):
-        if self.use_draw_order and self.component is not None:
+        if self.component is not None:
             self._layout_as_overlay(*args, **kw)
         else:
             super(Map, self).do_layout(*args, **kw)


### PR DESCRIPTION
Per enthought/chaco#671 and related changes to Enable and Chaco, the old `use_draw_order` trait is no longer available to check (it's always `True`, anyways).